### PR TITLE
Add Developerworks tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ A curated list of resources related to the Java Module System ([JSR 376](https:/
 ## Literature
 - [The Java Module System](https://www.manning.com/books/the-java-module-system?a_aid=nipa&a_bid=869915cb) (Nicolai Parlog; Manning)
 - [Java 9 Modularity](https://javamodularity.com) (Sander Mak & Paul Bakker; O'Reilly)
+- [Java 9+ modularity](https://developer.ibm.com/tutorials/java-modularity-1/) (Mohamed Taman; IBM Developerworks)
 
 
 ## Courses

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ A curated list of resources related to the Java Module System ([JSR 376](https:/
 ## Literature
 - [The Java Module System](https://www.manning.com/books/the-java-module-system?a_aid=nipa&a_bid=869915cb) (Nicolai Parlog; Manning)
 - [Java 9 Modularity](https://javamodularity.com) (Sander Mak & Paul Bakker; O'Reilly)
-- [Java 9+ modularity](https://developer.ibm.com/tutorials/java-modularity-1/) (Mohamed Taman; IBM Developerworks)
+- [Java 9+ modularity: How to design packages and create modules](https://developer.ibm.com/tutorials/java-modularity-3/) (Mohamed Taman; IBM Developerworks)
 
 
 ## Courses


### PR DESCRIPTION
This adds the IBM Developerwork's Java9+ tutorial. It starts right in the middle at the "design howto". That part showsl code. Interested readers can go back to the introduction.

https://developer.ibm.com/tutorials/java-modularity-3/